### PR TITLE
Adding sha224 to empty_hashs

### DIFF
--- a/lists/empty-hashes/list.json
+++ b/lists/empty-hashes/list.json
@@ -5,10 +5,12 @@
   "matching_attributes": [
     "md5",
     "sha1",
+    "sha224",
     "sha256",
     "sha512",
     "filename|md5",
     "filename|sha1",
+    "filename|sha224",
     "filename|sha256",
     "filename|sha512"
   ],


### PR DESCRIPTION
d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f is a sha224, let's use it.