### PR TITLE
Changed matching algorithm to domain to avoid false positive matches

### DIFF
--- a/lists/tlds/list.json
+++ b/lists/tlds/list.json
@@ -1296,8 +1296,8 @@
     "domain",
     "domain|ip"
   ],
-  "type": "substring",
+  "type": "hostname",
   "description": "Event contains one or more TLDs as attribute with an IDS flag set",
-  "version": 3,
+  "version": 4,
   "name": "TLDs as known by IANA"
 }


### PR DESCRIPTION
Changed matching algorithm to domain to avoid false positive matches + version bump to also cover the list of TLDs not just the list of 2nd level TLDs as known by Mozilla