### PR TITLE
Removing imgur.com from the list of known security providers/vendors blog domains

### DIFF
--- a/lists/security-provider-blogpost/list.json
+++ b/lists/security-provider-blogpost/list.json
@@ -637,7 +637,6 @@
     "f5.com",
     "www.rtl.lu",
     "www.cobaltstrike.com",
-    "imgur.com",
     "nvd.nist.gov",
     "devcentral.f5.com",
     "www.oracle.com",


### PR DESCRIPTION
Removing imgur.com from the list of known security providers/vendors blog domains as imgur.com is not a security provider / vendor.