### PR TITLE
Adding cape.contextis.com in sandbox warninglist

### DIFF
--- a/lists/automated-malware-analysis/list.json
+++ b/lists/automated-malware-analysis/list.json
@@ -27,6 +27,6 @@
     "securelist.com",
     "carbonblack.com",
     "app.any.run",
-	"cape.contextis.com"
+    "cape.contextis.com"
   ]
 }

--- a/lists/automated-malware-analysis/list.json
+++ b/lists/automated-malware-analysis/list.json
@@ -1,6 +1,6 @@
 {
   "name": "List of known domains used by automated malware analysis services & security vendors",
-  "version": 3,
+  "version": 4,
   "description": "Domains used by automated malware analysis services & security vendors",
   "type": "substring",
   "matching_attributes": [
@@ -26,6 +26,7 @@
     "symantec.com",
     "securelist.com",
     "carbonblack.com",
-    "app.any.run"
+    "app.any.run",
+	"cape.contextis.com"
   ]
 }


### PR DESCRIPTION
Seen cape.contextis.com in our twitter/pastebin curation.