### PR TITLE
Make sure that matching attributes are consistent for lists that include domains

### DIFF
--- a/lists/alexa/list.json
+++ b/lists/alexa/list.json
@@ -1,7 +1,8 @@
 {
   "matching_attributes": [
     "hostname",
-    "domain"
+    "domain",
+    "domain|ip"
   ],
   "description": "Event contains one or more entries from the top 1000 of the most used website (Alexa).",
   "list": [

--- a/lists/cisco_top1000/list.json
+++ b/lists/cisco_top1000/list.json
@@ -1,7 +1,8 @@
 {
   "matching_attributes": [
     "hostname",
-    "domain"
+    "domain",
+    "domain|ip"
   ],
   "description": "Event contains one or more entries from the top 1000 of the most used website (Cisco Umbrella).",
   "list": [

--- a/lists/microsoft-attack-simulator/list.json
+++ b/lists/microsoft-attack-simulator/list.json
@@ -2,6 +2,7 @@
   "matching_attributes": [
     "ip-src",
     "ip-dst",
+    "domain",
     "domain|ip",
     "hostname"
   ],


### PR DESCRIPTION
Updated warning lists that include domains to ensure that matching attributes are consistent, in particular to make sure that warning list gets applied to `domain|ip` attributes as well.