### PR TITLE
Removed pastebin.com, as it is not a security provider.

### DIFF
--- a/lists/security-provider-blogpost/list.json
+++ b/lists/security-provider-blogpost/list.json
@@ -57,7 +57,6 @@
     "www.google.com",
     "www.sophos.com",
     "www.threatexpert.com",
-    "pastebin.com",
     "www.seculert.com",
     "resources.infosecinstitute.com",
     "www.mcafee.com",


### PR DESCRIPTION
It is often used by malware to download configuration or payloads.