### PR TITLE
Dax30 initial add

### DIFF
--- a/lists/dax30/list.json
+++ b/lists/dax30/list.json
@@ -1,0 +1,26 @@
+{
+  "name": "List of known dax30 webpages",
+  "version": 1,
+  "description": "Event contains one or more entries of known dax30 webpages",
+  "matching_attributes": [
+    "domain",
+    "hostname",
+    "domain|ip"
+  ],
+  "type": "hostname",
+  "list": [
+    ".telekom.com",
+    ".telekom.de",
+    ".t-systems.com",
+    ".t-mobile.de",
+    ".innogy.com",
+    ".linde.de",
+    ".the-linde-group.com",
+    ".deutsche-boerse.com",
+    ".lufthansa.com",
+    ".rwe.com",
+    ".siemens.com",
+    ".volkswagen.de",
+    ".",
+  ]
+}

--- a/lists/dax30/list.json
+++ b/lists/dax30/list.json
@@ -21,6 +21,6 @@
     ".rwe.com",
     ".siemens.com",
     ".volkswagen.de",
-    ".",
+    ".bmw.de",
   ]
 }


### PR DESCRIPTION
DAX 30 initial version - Should be filled more intensively by the CERTs/SoCs of the particular DAX30 company