### PR TITLE
Fix generator.py:download_to_file

### DIFF
--- a/tools/generator.py
+++ b/tools/generator.py
@@ -21,7 +21,7 @@ def download_to_file(url, file):
 
         if(url_datetime > file_datetime):
             actual_download_to_file(url, file, user_agent)
-    except KeyError as ex:
+    except (KeyError, FileNotFoundError) as ex:
         logging.warning(str(ex))
         actual_download_to_file(url, file, user_agent)
         


### PR DESCRIPTION
Closes #156 

When some script which is using generator.py module (e.g. generate-publicdns.py) is run for the
first time, the file is missing and unhandled exception is thrown