### PR TITLE
Change hostname type to string type for multiple lists

### DIFF
--- a/lists/cisco_top1000/list.json
+++ b/lists/cisco_top1000/list.json
@@ -1010,5 +1010,5 @@
   ],
   "name": "Top 1000 websites from Cisco Umbrella",
   "type": "string",
-  "version": 20200916
+  "version": 202000923
 }

--- a/lists/cisco_top1000/list.json
+++ b/lists/cisco_top1000/list.json
@@ -1009,6 +1009,6 @@
     "domain|ip"
   ],
   "name": "Top 1000 websites from Cisco Umbrella",
-  "type": "hostname",
+  "type": "string",
   "version": 20200916
 }

--- a/lists/google/list.json
+++ b/lists/google/list.json
@@ -676,5 +676,5 @@
   ],
   "name": "List of known google domains",
   "type": "string",
-  "version": 4
+  "version": 5
 }

--- a/lists/google/list.json
+++ b/lists/google/list.json
@@ -675,6 +675,6 @@
     "domain|ip"
   ],
   "name": "List of known google domains",
-  "type": "hostname",
+  "type": "string",
   "version": 4
 }

--- a/lists/majestic_million/list.json
+++ b/lists/majestic_million/list.json
@@ -10007,6 +10007,6 @@
     "domain"
   ],
   "name": "Top 10K websites from Majestic Million",
-  "type": "hostname",
-  "version": 20200916
+  "type": "string",
+  "version": 20200923
 }

--- a/lists/microsoft-win10-connection-endpoints/list.json
+++ b/lists/microsoft-win10-connection-endpoints/list.json
@@ -152,6 +152,6 @@
     "domain|ip"
   ],
   "name": "List of known Windows 10 connection endpoints",
-  "type": "hostname",
+  "type": "string",
   "version": 1
 }

--- a/lists/microsoft-win10-connection-endpoints/list.json
+++ b/lists/microsoft-win10-connection-endpoints/list.json
@@ -153,5 +153,5 @@
   ],
   "name": "List of known Windows 10 connection endpoints",
   "type": "string",
-  "version": 1
+  "version": 2
 }

--- a/lists/microsoft/list.json
+++ b/lists/microsoft/list.json
@@ -200,5 +200,5 @@
   ],
   "name": "List of known microsoft domains",
   "type": "string",
-  "version": 3
+  "version": 4
 }

--- a/lists/microsoft/list.json
+++ b/lists/microsoft/list.json
@@ -199,6 +199,6 @@
     "domain|ip"
   ],
   "name": "List of known microsoft domains",
-  "type": "hostname",
+  "type": "string",
   "version": 3
 }

--- a/lists/university_domains/list.json
+++ b/lists/university_domains/list.json
@@ -9672,6 +9672,6 @@
     "domain|ip"
   ],
   "name": "University domains",
-  "type": "hostname",
-  "version": 20200916
+  "type": "string",
+  "version": 20200923
 }

--- a/tools/generate-cisco.py
+++ b/tools/generate-cisco.py
@@ -40,7 +40,7 @@ def process(file):
 
 def generate(sites, warninglist, dst):
     warninglist['version'] = get_version()
-    warninglist['type'] = 'hostname'
+    warninglist['type'] = 'string'
     warninglist['matching_attributes'] = [
         'hostname', 'domain', 'url', 'domain|ip']
     warninglist['list'] = []

--- a/tools/generate-university-domain-list.py
+++ b/tools/generate-university-domain-list.py
@@ -9,7 +9,7 @@ def process(url, dst):
     university_list = download(url).json()
 
     warninglist = {
-        'type': "hostname",
+        'type': "string",
         'name': "University domains",
         'matching_attributes': ['hostname', 'domain', 'url', 'domain|ip'],
         'version': get_version(),

--- a/tools/generate_majestic-million.py
+++ b/tools/generate_majestic-million.py
@@ -14,7 +14,7 @@ def process(file, dst):
         'version': get_version(),
         'description': 'Event contains one or more entries from the top 10K of the most used websites (Majestic Million).',
         'matching_attributes': ['hostname', 'domain'],
-        'type': 'hostname',
+        'type': 'string',
         'list': []
     }
 


### PR DESCRIPTION
These lists contain many legitimate domains that are not fully controlled by their owner and that could be found to host malicious content. As an example, while dropbox.com is a legitimate domain, it could be hosting some malicious content that we would want to block based on an indicator of compromise received. As such, we want those lists to be an exact match and not allow for any loose matching.