### PR TITLE
Adding replacement for wildcard and dash inputs

### DIFF
--- a/tools/generate-office365.py
+++ b/tools/generate-office365.py
@@ -45,7 +45,9 @@ def get_lists(url):
     for service in service_list:
         for url in service.get('urls', []):
             if url.find(".*.") == -1:
-                lurls.append(url.replace('*', ''))
+                lurls.append(url.replace('*.', '').replace('*-', '').replace('*', ''))
+            else:
+                lurls.append(url.rsplit('.*.',1)[1])
         for ip in service.get('ips', []):
             lips.append(ip)
 


### PR DESCRIPTION
Initial problems :

1. MISP script was not parsing correctly office endpoint items when those contained **“-*”** and **“.*”**. Those items where not included in the misp-warninglist which can cause issues if a feed publish one of those entries.

- Example of an item fetch from office 365 endpoint list

```
  {
    "id": 39,
    "serviceArea": "SharePoint",
    "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
    "urls": [
      "*.svc.ms",
      "*-files.sharepoint.com",
      "*-myfiles.sharepoint.com"
    ],
    "tcpPorts": "80,443",
    "expressRoute": false,
    "category": "Default",
    "required": true
  },

```

- When the initial script parsed office endpoint items containing **“-*”** and **“.*”** it ended up in the following format under **misp-warninglists/lists/microsoft-office365/list.json**. MISP was not adding those items in his warninglist.

```
{
  "description": "Office 365 URLs and IP address ranges",
  "list": [
				"-files.sharepoint.com",
				"-myfiles.sharepoint.com",
				Snip ….. snip….
				".svc.ms",

```

- With proposed code modification we have following office endpoint items parsed data under **misp-warninglists/lists/microsoft-office365/list.json** in a format that MISP will include the items in the misp-warninglist.

```
{
  "description": "Office 365 URLs and IP address ranges",
  "list": [
				"files.sharepoint.com",
				"myfiles.sharepoint.com",
				Snip ….. snip….
				"svc.ms",
```

2. MISP original script rejects any items that contained .*. in there DNS name. This can cause a loss of valuable item in the warninglist. But lucky the item "onmicrosoft.com" was already parse by a previous item so no entry was lost but this represent a risk if a new item is added with no prior classified item.

- With original script, office endpoint item that contains **.*.** will be rejected. 

```
for service in service_list:
    for url in service.get('urls', []):
        if url.find(".*.") == -1:
```

- Following office endpoint item was rejected “autodiscover.*.onmicrosoft.com”
```
{
    "id": 154,
    "serviceArea": "Exchange",
    "serviceAreaDisplayName": "Exchange Online",
    "urls": [
      "autodiscover.*.onmicrosoft.com"
    ],
    "tcpPorts": "80,443",
    "expressRoute": false,
    "category": "Default",
    "required": true
  }
```

Appendix:

- Endpoints of Office 365
          https://endpoints.office.com/endpoints/worldwide?clientrequestid=b10c5ed1-bad1-445f-b386-b919946339a7


