### PR TITLE
Added new type [wildlist] warninglist, that will exclude subdomains from warn

### DIFF
--- a/lists/wildlist/list.json
+++ b/lists/wildlist/list.json
@@ -2,7 +2,6 @@
   "description": "List will exclude all subdomains from warninglist if domain or subdomain exist in other warning lists.",
   "list": [
     "!.appspot.com",
-    "!.cloudapp.azure.com",
     "!.sytes.net",
     "!.weebly.com"
   ],

--- a/lists/wildlist/list.json
+++ b/lists/wildlist/list.json
@@ -1,0 +1,16 @@
+{
+  "description": "List will exclude all subdomains from warninglist if domain or subdomain exist in other warning lists.",
+  "list": [
+    "!.appspot.com",
+    "!.cloudapp.azure.com",
+    "!.sytes.net",
+    "!.weebly.com"
+  ],
+  "matching_attributes": [
+    "domain",
+    "hostname"
+  ],
+  "name": "Exclude subdomain from warn",
+  "type": "wildmask",
+  "version": 1
+}


### PR DESCRIPTION
List will exclude all subdomains from warninglist if domain or subdomain exist in other warning lists.
Domains should have prefix `!.` for easy eye identification.
For example:
If the wildlist list contains `!.example.com` and in another warninglist will be domain `example.com`, then subdomain `badsubdomain.example.com` will not be marked as warn.


