### PR TITLE
Adding matching type URL to warninglists

### DIFF
--- a/lists/bank-website/list.json
+++ b/lists/bank-website/list.json
@@ -1759,7 +1759,8 @@
   "matching_attributes": [
     "domain",
     "hostname",
-    "domain|ip"
+    "domain|ip",
+    "URL"
   ],
   "name": "List of known bank domains",
   "type": "hostname",

--- a/lists/cisco_top1000/list.json
+++ b/lists/cisco_top1000/list.json
@@ -1006,7 +1006,8 @@
     "hostname",
     "domain",
     "url",
-    "domain|ip"
+    "domain|ip",
+    "URL"
   ],
   "name": "Top 1000 websites from Cisco Umbrella",
   "type": "string",

--- a/lists/dax30/list.json
+++ b/lists/dax30/list.json
@@ -18,7 +18,8 @@
   "matching_attributes": [
     "domain",
     "hostname",
-    "domain|ip"
+    "domain|ip",
+    "URL"
   ],
   "name": "List of known dax30 webpages",
   "type": "hostname",

--- a/lists/google/list.json
+++ b/lists/google/list.json
@@ -672,7 +672,8 @@
   "matching_attributes": [
     "domain",
     "hostname",
-    "domain|ip"
+    "domain|ip",
+    "URL"
   ],
   "name": "List of known google domains",
   "type": "string",

--- a/lists/majestic_million/list.json
+++ b/lists/majestic_million/list.json
@@ -10004,7 +10004,8 @@
   ],
   "matching_attributes": [
     "hostname",
-    "domain"
+    "domain",
+    "URL"
   ],
   "name": "Top 10K websites from Majestic Million",
   "type": "string",

--- a/lists/microsoft-attack-simulator/list.json
+++ b/lists/microsoft-attack-simulator/list.json
@@ -18,7 +18,8 @@
     "ip-dst",
     "domain",
     "domain|ip",
-    "hostname"
+    "hostname",
+    "URL"
   ],
   "name": "List of known Office 365 Attack Simulator used for phishing awareness campaigns",
   "type": "substring",

--- a/lists/microsoft-office365/list.json
+++ b/lists/microsoft-office365/list.json
@@ -336,7 +336,8 @@
   "matching_attributes": [
     "domain",
     "domain|ip",
-    "hostname"
+    "hostname",
+    "URL"
   ],
   "name": "List of known Office 365 URLs",
   "type": "string",

--- a/lists/microsoft-win10-connection-endpoints/list.json
+++ b/lists/microsoft-win10-connection-endpoints/list.json
@@ -149,7 +149,8 @@
   "matching_attributes": [
     "domain",
     "hostname",
-    "domain|ip"
+    "domain|ip",
+    "URL"
   ],
   "name": "List of known Windows 10 connection endpoints",
   "type": "string",

--- a/lists/microsoft/list.json
+++ b/lists/microsoft/list.json
@@ -196,7 +196,8 @@
   "matching_attributes": [
     "domain",
     "hostname",
-    "domain|ip"
+    "domain|ip",
+    "URL"
   ],
   "name": "List of known microsoft domains",
   "type": "string",

--- a/lists/rfc6761/list.json
+++ b/lists/rfc6761/list.json
@@ -26,7 +26,8 @@
   "matching_attributes": [
     "hostname",
     "domain",
-    "domain|ip"
+    "domain|ip",
+    "URL"
   ],
   "name": "List of RFC 6761 Special-Use Domain Names",
   "type": "string",

--- a/lists/tlds/list.json
+++ b/lists/tlds/list.json
@@ -1513,7 +1513,8 @@
   "matching_attributes": [
     "hostname",
     "domain",
-    "domain|ip"
+    "domain|ip",
+    "URL"
   ],
   "name": "TLDs as known by IANA",
   "type": "string",


### PR DESCRIPTION
All MISP Warninglists are not created equal. MISP warninglists have their characterization defined by specifying types in their “matching_attributes” --> Ex: "matching_attributes": ["domain", "hostname", "url"  ],
 
The issue we are seeing is that a domain can also be an URL but some warninglists are missing the “matching_attributes” “URL” so the IoC will not be blocked if the type is “URL”. 
 
Like in the below example, if the attribute (IoC) type is URL and the warninglisst doesn’t have the “matching_attributes” “URL”, the warninglists its ignored by MISP.

- The attribute (IoC) “0f3kjf7t0dbj.wpeproxy.com” with type “domain” and “URL” is part of a warninglist with “domain” and “URL” matching_attributes. This causes the warninglist to block both attributes since it’s a protected domain and URL. 
--> "matching_attributes": ["domain", "hostname", "url"]

-	The attribute (IoC) “fs.microsoft.com” with type “domain” and “URL” is part of LIST OF KNOWN WINDOWS 10 CONNECTION ENDPOINTS with only the “domain” attributes. This causes the warninglists to block only the domain attributes since it’s a protected domain. The URL IoC will not be blocked since the warninglists haven’t detected the “URL” type.
-->	"matching_attributes": ["domain", "hostname", "domain|ip"]


<img width="1280" alt="Screen Shot 2020-10-30 at 1 41 23 PM" src="https://user-images.githubusercontent.com/72164114/97739031-9ff57b00-1ab5-11eb-8ffa-3b56371b0de7.png">
