### PR TITLE
VPN list is outdated

### DIFF
--- a/tools/generate-vpn.py
+++ b/tools/generate-vpn.py
@@ -18,10 +18,10 @@ def process(url, dst):
 
 
 if __name__ == '__main__':
-    vpn_base_url = 'https://raw.githubusercontent.com/ejrv/VPNs/master/'
-    uri_list = ['vpn-ipv4', 'vpn-ipv6']
+    vpn_base_url_v4 = 'https://raw.githubusercontent.com/X4BNet/lists_vpn/main/vpn-ipv4.txt'
+    vpn_base_url_v6 = 'https://raw.githubusercontent.com/ejrv/VPNs/master/vpn-ipv6.txt'
 
-    for uri in uri_list:
-        url = vpn_base_url + uri + '.txt'
+    for url in [vpn_base_url_v4, vpn_base_url_v6]:
+        uri = url.split('/')[-1]
         uri.split('-')[1].replace('ip', 'IP')
         process(url, uri)


### PR DESCRIPTION
github.com/ejrv/VPNs/ has not been refreshed in 24 months.
https://github.com/X4BNet/lists_vpn/ seems to have replicated that effort for ipv4. No new source found for ipv6
Pros:
- Code for generation is in repository

Cons:
- Unsure about quality. Lots of ASN as source of data.
- No IPV6 data

Comparable open source sources:
- Firehol https://github.com/firehol/blocklist-ipsets / datacenter.ipset . Source data (https://github.com/client9/ipcat) is outdated from 2019
- https://github.com/jhassine/server-ip-addresses limited provider list
- https://incolumitas.com/pages/Datacenter-IP-API/ API, smaller list

Others sources seem commercial (Udger, securitytrails)