### PR TITLE
Apply IP-based RFC warning lists on `ip-*|port` combinations

### DIFF
--- a/lists/ipv6-linklocal/list.json
+++ b/lists/ipv6-linklocal/list.json
@@ -6,9 +6,11 @@
   "matching_attributes": [
     "ip-src",
     "ip-dst",
-    "domain|ip"
+    "domain|ip",
+    "ip-dst|port",
+    "ip-src|port"
   ],
   "name": "List of IPv6 link local blocks",
   "type": "cidr",
-  "version": 2
+  "version": 3
 }

--- a/lists/rfc1918/list.json
+++ b/lists/rfc1918/list.json
@@ -8,9 +8,11 @@
   "matching_attributes": [
     "ip-src",
     "ip-dst",
-    "domain|ip"
+    "domain|ip",
+    "ip-dst|port",
+    "ip-src|port"
   ],
   "name": "List of RFC 1918 CIDR blocks",
   "type": "cidr",
-  "version": 4
+  "version": 5
 }

--- a/lists/rfc3849/list.json
+++ b/lists/rfc3849/list.json
@@ -6,9 +6,11 @@
   "matching_attributes": [
     "ip-src",
     "ip-dst",
-    "domain|ip"
+    "domain|ip",
+    "ip-dst|port",
+    "ip-src|port"
   ],
   "name": "List of RFC 3849 CIDR blocks",
   "type": "cidr",
-  "version": 3
+  "version": 4
 }

--- a/lists/rfc5735/list.json
+++ b/lists/rfc5735/list.json
@@ -20,9 +20,11 @@
   "matching_attributes": [
     "ip-src",
     "ip-dst",
-    "domain|ip"
+    "domain|ip",
+    "ip-dst|port",
+    "ip-src|port"
   ],
   "name": "List of RFC 5735 CIDR blocks",
   "type": "cidr",
-  "version": 4
+  "version": 5
 }

--- a/lists/rfc6598/list.json
+++ b/lists/rfc6598/list.json
@@ -6,9 +6,11 @@
   "matching_attributes": [
     "ip-src",
     "ip-dst",
-    "domain|ip"
+    "domain|ip",
+    "ip-dst|port",
+    "ip-src|port"
   ],
   "name": "List of RFC 6598 CIDR blocks",
   "type": "cidr",
-  "version": 4
+  "version": 5
 }


### PR DESCRIPTION
A community member recently published an RFC-1918 `ip-dst|port` with the IDS flag (`192.168.31.210:80`). While we expected the warning list would catch it, we observed the indicator was missed as RFC-based CIDR warning lists do currently not apply on the `ip-*|port` combinations. This pull requests changes that.

It might be worth considering applying a similar update to other CIDR-based warning lists as for example the "List of known IPv4 public DNS resolvers" would still allow for `8.8.8.8|53`.