### PR TITLE
Update StackPatch ipblocks URL

### DIFF
--- a/tools/generate-stackpath.py
+++ b/tools/generate-stackpath.py
@@ -93,7 +93,7 @@ def process(files, dst):
 
 if __name__ == '__main__':
     # Base url where a text file is attached https://support.stackpath.com/hc/en-us/articles/360001091666-Whitelist-CDN-WAF-IP-Blocks"
-    sp_base_url = "https://support.stackpath.com/hc/en-us/article_attachments/360096407372/ipblocks.txt"
+    sp_base_url = "https://k3t9x2h3.map2.ssl.hwcdn.net/ipblocks.txt"
     filename = 'ipblocks.txt'
     sp_dst = 'stackpath'
 


### PR DESCRIPTION
Addressing #215 to update the Stackpath ipblocks URL to use the new one linked from the existing article.

The new location appears to be within the "Highwinds CDN" hwcdn.net.