### PR TITLE
Add translate.goog to Google list

### DIFF
--- a/lists/google/list.json
+++ b/lists/google/list.json
@@ -194,6 +194,7 @@
     ".google.vg",
     ".google.vu",
     ".google.ws",
+    ".translate.goog",
     "1e100.net",
     "466453.com",
     "abc.xyz",
@@ -676,5 +677,5 @@
   ],
   "name": "List of known google domains",
   "type": "string",
-  "version": 5
+  "version": 6
 }


### PR DESCRIPTION
Subdomains of `.translate.goog` are used to present translated websites, for example:

```
https://example-com.translate.goog/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp
```