### PR TITLE
Add Captive Portal detection hostnames

### DIFF
--- a/lists/captive-portals/list.json
+++ b/lists/captive-portals/list.json
@@ -1,0 +1,37 @@
+{
+  "description": "Hostnames used by different desktop and mobile device operating systems for captive portal detection as documented by the Wireless Broadband Alliance.",
+  "list": [
+    "www.apple.com",
+    "www.appleiphonecell.com",
+    "captive.apple.com",
+    "www.airport.us",
+    "www.ibook.info",
+    "www.itools.info",
+    "www.thinkdifferent.us",
+    "apple.com",
+    "clients3.google.com",
+    "clients4.google.com",
+    "android.clients.google.com",
+    "connectivitycheck.android.com",
+    "connectivitycheck.gstatic.com",
+    "www.gstatic.com",
+    "www.google.com",
+    "www.androidbak.net",
+    "connectivitycheck.android.com",
+    "connectivitycheck.gstatic.com",
+    "d2uzsrnmmf6tds.cloudfront.net",
+    "msftncsi.com",
+    "www.msftconnecttest.com",
+    "detectportal.firefox.com",
+    "spectrum.s3.amazonaws.com"
+  ],
+  "matching_attributes": [
+    "hostname",
+    "domain",
+    "url",
+    "domain|ip"
+  ],
+  "name": "Captive Portal Detection Hostnames",
+  "type": "string",
+  "version": 20230130
+}


### PR DESCRIPTION
Warning list with hostnames used by different OS and devices (Mac OS, Microsoft Windows, Apple iOS, Google Android, Samsung Android, HTC Android, Amazon FireOS, Firefox Browser, Chrome OS) for detection of captive portals used in public Wi-Fi networks. The source for the list is the official documentation of the Wireless Broadband Alliance:  https://captivebehavior.wballiance.com/ 
Additional Microsoft hostname www.msftconnecttest.com added from: https://learn.microsoft.com/de-de/troubleshoot/windows-client/networking/internet-explorer-edge-open-connect-corporate-public-network