### PR TITLE
Add List for Censys CIDR blocks

### DIFF
--- a/lists/Censys_Scanning/list.json
+++ b/lists/Censys_Scanning/list.json
@@ -2,7 +2,7 @@
   "name": "Censys IP Ranges Used for Scanning",
   "type": "cidr",
   "version": 1,
-  "description": "List containing IP's accocaited with Censys scanning",
+  "description": "List containing IP's accocaited with Censys scanning [https://support.censys.io/hc/en-us/articles/360043177092-Opt-Out-of-Data-Collection#Can_I_opt_out_of_Censys_data_collection?]",
   "matching_attributes": [
     "ip-src",
     "ip-dst",

--- a/lists/Censys_Scanning/list.json
+++ b/lists/Censys_Scanning/list.json
@@ -2,7 +2,7 @@
   "name": "Censys IP Ranges Used for Scanning",
   "type": "cidr",
   "version": 1,
-  "description": "List containing IP's accocaited with Censys scanning [https://support.censys.io/hc/en-us/articles/360043177092-Opt-Out-of-Data-Collection#Can_I_opt_out_of_Censys_data_collection?]",
+  "description": "List containing IP's associated with Censys scanning [https://support.censys.io/hc/en-us/articles/360043177092-Opt-Out-of-Data-Collection#Can_I_opt_out_of_Censys_data_collection?]",
   "matching_attributes": [
     "ip-src",
     "ip-dst",

--- a/lists/Censys_Scanning/list.json
+++ b/lists/Censys_Scanning/list.json
@@ -1,0 +1,22 @@
+{
+  "name": "Censys IP Ranges Used for Scanning",
+  "type": "cidr",
+  "version": 1,
+  "description": "List containing IP's accocaited with Censys scanning",
+  "matching_attributes": [
+    "ip-src",
+    "ip-dst",
+    "domain|ip",
+    "ip-dst|port",
+    "ip-src|port"
+  ],
+  "list": [
+    "162.142.125.0/24",
+    "167.94.138.0/24",
+    "167.94.145.0/24",
+    "167.94.146.0/24",
+    "167.248.133.0/24",
+    "2602:80d:1000:b0cc:e::/80",
+	"2620:96:e000:b0cc:e::/80"
+  ]
+}


### PR DESCRIPTION
Howdy

I've found this list to be useful in our organisations MISP instance as IP Addresses belonging to Censys are regularly reported for abuse due to their scanning of public facing systems, which while benign does tend to hit IPS Devices/Honeypots and be reported for abuse. 

Unfortunately I couldn't create a generator script as I was only able to find these CIDR blocks on a [Censys support page](https://support.censys.io/hc/en-us/articles/360043177092-Opt-Out-of-Data-Collection#Can_I_opt_out_of_Censys_data_collection?) that didn't link to a flat txt/json file with the IP's.