### PR TITLE
Update Apple IP ranges

### DIFF
--- a/lists/apple/list.json
+++ b/lists/apple/list.json
@@ -1,7 +1,10 @@
 {
   "description": "IP ranges assigned to Apple",
   "list": [
-    "17.0.0.0/8"
+    "17.0.0.0/8",
+    "192.12.74.0/24",
+    "192.42.249.0/24",
+    "204.79.190.0/24"
   ],
   "matching_attributes": [
     "ip-src",

--- a/lists/apple/list.json
+++ b/lists/apple/list.json
@@ -15,5 +15,5 @@
   ],
   "name": "List of known Apple IP ranges",
   "type": "cidr",
-  "version": 20240422
+  "version": 20241023
 }


### PR DESCRIPTION
Update from ARIN allocation for Apple with OrgId `APPLEC-1-Z`