### PR TITLE
Update security-provider-blogpost list.json

### DIFF
--- a/lists/security-provider-blogpost/list.json
+++ b/lists/security-provider-blogpost/list.json
@@ -654,10 +654,9 @@
     "domain|ip",
     "hostname",
     "url",
-    "uri",
-    "link"
+    "uri"
   ],
   "name": "List of known security providers/vendors blog domain",
   "type": "hostname",
-  "version": 4
+  "version": 5
 }


### PR DESCRIPTION
A "link" attribute should not trigger the match.

(other warninglists such as banksites, url shorteners etc. do not include the "link" attribute)