### PR TITLE
Use recommended Zscaler list

### DIFF
--- a/tools/generate-zscaler.py
+++ b/tools/generate-zscaler.py
@@ -17,7 +17,7 @@ def process(file, dst):
     warninglist = {
         'name': 'List of known Zscaler IP address ranges',
         'version': get_version(),
-        'description': 'Zscaler IP address ranges (https://config.zscaler.com/api/zscaler.net/hubs/cidr/json/required)',
+        'description': 'Zscaler IP address ranges (https://config.zscaler.com/api/zscaler.net/hubs/cidr/json/recommended)',
         'type': 'cidr',
         'list': consolidate_networks(l),
         'matching_attributes': ["ip-src", "ip-dst", "domain|ip", "ip-src|port", "ip-dst|port"]
@@ -27,7 +27,7 @@ def process(file, dst):
 
 
 if __name__ == '__main__':
-    zscaler_url = "https://config.zscaler.com/api/zscaler.net/hubs/cidr/json/required"
+    zscaler_url = "https://config.zscaler.com/api/zscaler.net/hubs/cidr/json/recommended"
     zscaler_file = "zscaler_ip-ranges.json"
     zscaler_dst = "zscaler"
 


### PR DESCRIPTION
Change from "required" Zscaler list to "recommended" to get the whole Zscaler IP block.

Example : 147.161.183.10 -> Zscaler IP, nor present in required but present in recommended