### PR TITLE
Add Internet Cleanup Foundation scanner warninglist generator

### DIFF
--- a/generate_all.sh
+++ b/generate_all.sh
@@ -44,6 +44,7 @@ python3 generate-cisco-umbrella-blockpage.py
 python3 generate-zscaler.py
 python3 generate-onyphe-scanner.py
 python3 generate-modat-scanner.py
+python3 generate-internetcleanup-scanner.py
 popd
 
 ./jq_all_the_things.sh

--- a/lists/internetcleanup-scanner/list.json
+++ b/lists/internetcleanup-scanner/list.json
@@ -1,0 +1,14 @@
+{
+  "description": "Internet Cleanup Foundation scaninfo (https://internetcleanup.foundation/scaninfo/)",
+  "list": [],
+  "matching_attributes": [
+    "ip-src",
+    "ip-dst",
+    "domain|ip",
+    "ip-src|port",
+    "ip-dst|port"
+  ],
+  "name": "List of published IP address ranges for Internet Cleanup Foundation scanners",
+  "type": "cidr",
+  "version": 0
+}

--- a/tools/generate-internetcleanup-scanner.py
+++ b/tools/generate-internetcleanup-scanner.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module downloads scanner IPs published by Internet Cleanup Foundation
+and updates the corresponding warninglist.
+"""
+
+import ipaddress
+import re
+
+from generator import download, get_version, write_to_file, consolidate_networks
+
+
+def process(content: str, dst: str):
+    """Parse scanner IPs from the Scaninfo page and generate warninglist JSON."""
+    candidates = re.findall(r"\b(?:\d{1,3}\.){3}\d{1,3}(?:/\d{1,2})?\b", content)
+
+    networks = []
+    for candidate in candidates:
+        try:
+            network = ipaddress.ip_network(candidate, strict=False)
+        except ValueError:
+            continue
+
+        if network.version != 4:
+            continue
+
+        if network.network_address == ipaddress.IPv4Address("0.0.0.0"):
+            continue
+
+        networks.append(str(network))
+
+    warninglist = {
+        "name": "List of published IP address ranges for Internet Cleanup Foundation scanners",
+        "version": get_version(),
+        "description": "Internet Cleanup Foundation scaninfo (https://internetcleanup.foundation/scaninfo/)",
+        "type": "cidr",
+        "list": consolidate_networks(networks),
+        "matching_attributes": [
+            "ip-src",
+            "ip-dst",
+            "domain|ip",
+            "ip-src|port",
+            "ip-dst|port",
+        ],
+    }
+
+    write_to_file(warninglist, dst)
+
+
+if __name__ == "__main__":
+    URL = "https://internetcleanup.foundation/scaninfo/"
+    DST = "internetcleanup-scanner"
+
+    response = download(URL)
+    response.raise_for_status()
+    process(response.text, DST)


### PR DESCRIPTION
### Motivation
- Provide a new warning-list of scanner IPs published on the Internet Cleanup Foundation `scaninfo` page so these scanners can be tracked and filtered.
- Ensure extracted values are normalized and that invalid/placeholder entries such as `0.0.0.0` are excluded.

### Description
- Add a new generator script `tools/generate-internetcleanup-scanner.py` that downloads `https://internetcleanup.foundation/scaninfo/`, extracts IPv4 and CIDR entries using a regex, normalizes them with `ipaddress.ip_network(..., strict=False)`, filters to IPv4 and excludes `0.0.0.0`, consolidates ranges with `consolidate_networks`, and writes the JSON via `write_to_file`.
- Add a placeholder warning-list file at `lists/internetcleanup-scanner/list.json` to provide an in-repo artifact that the generator will update.
- Include the new generator in the main generation flow by adding `python3 generate-internetcleanup-scanner.py` to `generate_all.sh`.

### Testing
- Ran `python -m py_compile tools/generate-internetcleanup-scanner.py` which succeeded. 
- Validated `lists/internetcleanup-scanner/list.json` with `python -m json.tool` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a181028cb308324bc4d89cb2a44499f)